### PR TITLE
Fix Terraria.MessageBuffer error

### DIFF
--- a/Components/StorageComponent.cs
+++ b/Components/StorageComponent.cs
@@ -19,14 +19,9 @@ namespace MagicStorageExtra.Components
         {
             Main.tileSolidTop[Type] = true;
             Main.tileFrameImportant[Type] = true;
-            TileObjectData.newTile.Width = 2;
-            TileObjectData.newTile.Height = 2;
+            TileObjectData.newTile.CopyFrom(TileObjectData.Style2x2);
             TileObjectData.newTile.Origin = new Point16(1, 1);
-            TileObjectData.newTile.CoordinateHeights = new[] {16, 16};
-            TileObjectData.newTile.CoordinateWidth = 16;
-            TileObjectData.newTile.CoordinatePadding = 2;
             TileObjectData.newTile.HookCheck = new PlacementHook(CanPlace, -1, 0, true);
-            TileObjectData.newTile.UsesCustomCanPlace = true;
             ModifyObjectData();
             ModTileEntity tileEntity = GetTileEntity();
             if (tileEntity != null)


### PR DESCRIPTION
Using tModLoader v0.11.8.4 and MagicStorageExtra 0.5.3.10, placing a Storage Heart (not tested with other tiles) throws the following error on the server: `error on message Terraria.MessageBuffer`. After a bit of reverse-engineering, an exception was thrown when handling the tile placement, in `Terraria.TileObject::CanPlace`

Note that for whatever reason, it seems that CanPlace is ran 4 times before placing the tile, and 1 time after placing it (the last one was the failing one). I suspect tModLoader to be the cause of this, since the throwing CanPlace stacktrace doesn't run any mod code (tested using a try/can in a MonoMod hook).
This may also need further testing before approval, since I'm not a experienced Terraria modder.

(This bug also affects MagicStorage 0.4.3.5)