### PR TITLE
Add config option to clear last selected recipe from the Crafting Interface

### DIFF
--- a/CraftingGUI.cs
+++ b/CraftingGUI.cs
@@ -66,7 +66,7 @@ namespace MagicStorageExtra
 		private static readonly Dictionary<int, int> itemCounts = new Dictionary<int, int>();
 		private static List<Recipe> recipes = new List<Recipe>();
 		private static List<bool> recipeAvailable = new List<bool>();
-		private static Recipe selectedRecipe;
+		public static Recipe selectedRecipe;
 		private static int numRows;
 		private static int displayRows;
 		private static bool slotFocus;

--- a/MagicStorageConfig.cs
+++ b/MagicStorageConfig.cs
@@ -35,6 +35,11 @@ namespace MagicStorageExtra
 		[DefaultValue(false)]
 		public bool clearSearchText;
 
+		[Label("Clear selected item")]
+		[Tooltip("Enable to clear the last selected item when opening the UI")]
+		[DefaultValue(true)]
+		public bool clearSelectedItem;
+
 		[Label("Show estimated item dps")]
 		[Tooltip("Enable to show the estimated dps of the item as a tooltip")]
 		[DefaultValue(true)]
@@ -51,6 +56,8 @@ namespace MagicStorageExtra
 		[JsonIgnore] public static bool QuickStackDepositMode => Instance.quickStackDepositMode;
 
 		[JsonIgnore] public static bool ClearSearchText => Instance.clearSearchText;
+
+		[JsonIgnore] public static bool ClearSelectedItem => Instance.clearSelectedItem;
 
 		[JsonIgnore] public static bool ShowItemDps => Instance.showItemDps;
 

--- a/MagicStorageConfig.cs
+++ b/MagicStorageConfig.cs
@@ -35,10 +35,10 @@ namespace MagicStorageExtra
 		[DefaultValue(false)]
 		public bool clearSearchText;
 
-		[Label("Clear selected item")]
-		[Tooltip("Enable to clear the last selected item when opening the UI")]
+		[Label("Clear selected recipe")]
+		[Tooltip("Enable to clear the last selected recipe when opening the Crafting Interface")]
 		[DefaultValue(true)]
-		public bool clearSelectedItem;
+		public bool clearSelectedRecipe;
 
 		[Label("Show estimated item dps")]
 		[Tooltip("Enable to show the estimated dps of the item as a tooltip")]
@@ -57,7 +57,7 @@ namespace MagicStorageExtra
 
 		[JsonIgnore] public static bool ClearSearchText => Instance.clearSearchText;
 
-		[JsonIgnore] public static bool ClearSelectedItem => Instance.clearSelectedItem;
+		[JsonIgnore] public static bool ClearSelectedRecipe => Instance.clearSelectedRecipe;
 
 		[JsonIgnore] public static bool ShowItemDps => Instance.showItemDps;
 

--- a/StoragePlayer.cs
+++ b/StoragePlayer.cs
@@ -138,7 +138,7 @@ namespace MagicStorageExtra
 				CraftingGUI.searchBar?.Reset();
 			}
 
-			if (MagicStorageConfig.ClearSelectedItem)
+			if (MagicStorageConfig.ClearSelectedRecipe)
 			{
 				CraftingGUI.selectedRecipe = null;
 			}

--- a/StoragePlayer.cs
+++ b/StoragePlayer.cs
@@ -138,6 +138,11 @@ namespace MagicStorageExtra
 				CraftingGUI.searchBar?.Reset();
 			}
 
+			if (MagicStorageConfig.ClearSelectedItem)
+			{
+				CraftingGUI.selectedRecipe = null;
+			}
+
 			StorageGUI.RefreshItems();
 		}
 


### PR DESCRIPTION
Adds a config option to clear the last selected recipe from the Crafting Interface when opened (default: true), as the Crafting Interface could spit out errors in chat or bug out entirely depending on the last crafted recipe - mostly noticeable in multiplayer.