### PR TITLE
SHIFT+Click on inventory item during crafting deposits the item into storage instead of depositing as a station

### DIFF
--- a/StoragePlayer.cs
+++ b/StoragePlayer.cs
@@ -186,32 +186,15 @@ namespace MagicStorageExtra
 				return false;
 			int oldType = item.type;
 			int oldStack = item.stack;
-			if (StorageCrafting())
+			
+			if (Main.netMode == NetmodeID.SinglePlayer)
 			{
-				if (false)
-				{
-					if (Main.netMode == NetmodeID.SinglePlayer)
-					{
-						GetCraftingAccess().TryDepositStation(item);
-					}
-					else
-					{
-						NetHelper.SendDepositStation(GetCraftingAccess().ID, item);
-						item.SetDefaults(0, true);
-					}
-				}
+				GetStorageHeart().DepositItem(item);
 			}
 			else
 			{
-				if (Main.netMode == NetmodeID.SinglePlayer)
-				{
-					GetStorageHeart().DepositItem(item);
-				}
-				else
-				{
-					NetHelper.SendDeposit(GetStorageHeart().ID, item);
-					item.SetDefaults(0, true);
-				}
+				NetHelper.SendDeposit(GetStorageHeart().ID, item);
+				item.SetDefaults(0, true);
 			}
 
 			if (item.type != oldType || item.stack != oldStack)


### PR DESCRIPTION
Moving items between inventory and storage is a very common task and needs as many ways to do it as possible. Moving items into station slots can require a few more clicks since it is such a rare task.